### PR TITLE
title 'News' for News page

### DIFF
--- a/pages/news.tsx
+++ b/pages/news.tsx
@@ -11,7 +11,7 @@ export default function News(props: Props) {
   const intl = useIntl();
   const title = intl.formatMessage({
     id: 'pages.blog.title',
-    defaultMessage: 'Blog',
+    defaultMessage: 'News',
   });
   return (
     <div>


### PR DESCRIPTION
noticed browser title when on the 'News' page shows 'Blog', instead of 'News'.   dunno if i'm being helpful here...
i guess this is just a bug report in case that's wanted.. :)