### PR TITLE
Fix #110: Create dedicated Hall of Fame page

### DIFF
--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -201,12 +201,9 @@ export default function Footer() {
                   <FormattedMessage defaultMessage="Contribute to Ergo" id="footer.community.3" />
                 </Link>
               </li>
-              <li className="mb-4">
-                <Link
-                  href="/community/#HallOfFame"
-                  className="text-black dark:text-gray-300 cursor-pointer"
-                >
-                  <FormattedMessage defaultMessage="Hall of Fame" id="footer.community.4" />
+              <li className="mb-2">
+                <Link href="/hall-of-fame">
+                  <FormattedMessage id="footer.community.4" defaultMessage="Hall of Fame" />
                 </Link>
               </li>
               <li className="mb-4">

--- a/components/Navigation.tsx
+++ b/components/Navigation.tsx
@@ -202,7 +202,7 @@ function Navigation({ enableLanguages = true }) {
 
                       <li className="mb-2">
                         <Link
-                          href="/community/#HallOfFame"
+                          href="/hall-of-fame"
                           aria-label={intl.formatMessage({
                             id: 'footer.community.4',
                             defaultMessage: 'Hall of Fame',

--- a/components/NavigationMobileMenu.tsx
+++ b/components/NavigationMobileMenu.tsx
@@ -80,7 +80,7 @@ export default function NavigationMobileMenu() {
               </li>
 
               <li className="mb-2">
-                <Link href="/community/#HallOfFame">
+                <Link href="/hall-of-fame">
                   <FormattedMessage defaultMessage="Hall of Fame" id="footer.community.4" />
                 </Link>
               </li>

--- a/components/community/HallOfFame.tsx
+++ b/components/community/HallOfFame.tsx
@@ -1,8 +1,7 @@
-import { Tab } from '@headlessui/react';
-import Image from 'next/image';
-import Link from 'next/link';
 import { FormattedMessage } from 'react-intl';
 import { Github, Linkedin, PersonPlaceholder, X } from '../icons';
+import Image from 'next/image';
+import Link from 'next/link';
 
 type Props = {
   teamMembers?: any;
@@ -70,13 +69,13 @@ function HallOfFamePerson(props: HallOfFamePersonProps) {
   );
 }
 
-function GroupPersons(data: any, group: string) {
+function AllPersons(data: any) {
+  // Combine all groups into one array
   let persons: Array<any> = [];
   data.forEach(function (person: any) {
-    if (group == person.attributes.group) {
-      persons.push(person);
-    }
+    persons.push(person);
   });
+  
   return (
     <div className="flex overflow-x-auto space-x-8 mt-8 no-scrollbar pb-10 lg:grid lg:grid-cols-3 lg:justify-around lg:space-x-0 lg:gap-y-20 lg:gap-x-8">
       {persons?.map((person: any, i: number) => (
@@ -135,48 +134,10 @@ export default function HallOfFame(props: Props) {
         </div>
       </div>
       <div>
-        <Tab.Group>
-          <Tab.List className="flex justify-around mt-16">
-            <Tab
-              className={({ selected }) =>
-                selected
-                  ? 'font-subtitle-3-uppercase text-brand-orange dark:text-brand-orange underline underline-offset-4'
-                  : 'font-subtitle-3-uppercase'
-              }
-            >
-              <FormattedMessage defaultMessage={`CORE`} id="components.hallOfFame.tab1" />
-            </Tab>
-            <Tab
-              className={({ selected }) =>
-                selected
-                  ? 'font-subtitle-3-uppercase text-brand-orange dark:text-brand-orange underline underline-offset-4'
-                  : 'font-subtitle-3-uppercase'
-              }
-            >
-              <FormattedMessage defaultMessage={`COMMUNITY`} id="components.hallOfFame.tab2" />
-            </Tab>
-            <Tab
-              className={({ selected }) =>
-                selected
-                  ? 'font-subtitle-3-uppercase text-brand-orange dark:text-brand-orange underline underline-offset-4'
-                  : 'font-subtitle-3-uppercase'
-              }
-            >
-              <FormattedMessage defaultMessage={`FOUNDATION`} id="components.hallOfFame.tab3" />
-            </Tab>
-          </Tab.List>
-          <Tab.Panels className="mt-16">
-            <Tab.Panel className="outline-none">
-              {GroupPersons(props.teamMembers, 'ecosystem_core')}
-            </Tab.Panel>
-            <Tab.Panel className="outline-none">
-              {GroupPersons(props.teamMembers, 'community')}
-            </Tab.Panel>
-            <Tab.Panel className="outline-none">
-              {GroupPersons(props.teamMembers, 'ergo_foundation')}
-            </Tab.Panel>
-          </Tab.Panels>
-        </Tab.Group>
+        {/* Removed tabs and displaying all members together */}
+        <div className="mt-16">
+          {AllPersons(props.teamMembers)}
+        </div>
       </div>
     </div>
   );

--- a/content/compiled-locales/PL.json
+++ b/content/compiled-locales/PL.json
@@ -1,0 +1,1910 @@
+{
+  "blog.media.read": [
+    {
+      "type": 0,
+      "value": "CZYTAJ"
+    }
+  ],
+  "blog.news.read": [
+    {
+      "type": 0,
+      "value": "CZYTAJ"
+    }
+  ],
+  "blog.post.backToAll": [
+    {
+      "type": 0,
+      "value": "POWRÓT DO WSZYSTKICH WPISÓW"
+    }
+  ],
+  "blog.post.machineTranslated": [
+    {
+      "type": 0,
+      "value": "Ta strona została przetłumaczona maszynowo."
+    }
+  ],
+  "blog.post.sharePost": [
+    {
+      "type": 0,
+      "value": "Udostępnij wpis"
+    }
+  ],
+  "blog.post.translationUnavailable": [
+    {
+      "type": 0,
+      "value": "Tłumaczenie tymczasowo niedostępne. Wyświetlanie oryginalnej wersji angielskiej."
+    }
+  ],
+  "categoryPicker.categories": [
+    {
+      "type": 0,
+      "value": "Kategorie"
+    }
+  ],
+  "common.close": [
+    {
+      "type": 0,
+      "value": "Zamknij"
+    }
+  ],
+  "common.next": [
+    {
+      "type": 0,
+      "value": "Dalej"
+    }
+  ],
+  "common.previous": [
+    {
+      "type": 0,
+      "value": "Wstecz"
+    }
+  ],
+  "components.ContributeForm.company.subTitle": [
+    {
+      "type": 0,
+      "value": "Chcesz zostać partnerem?"
+    }
+  ],
+  "components.ContributeForm.company.title": [
+    {
+      "type": 0,
+      "value": "Dla "
+    },
+    {
+      "children": [
+        {
+          "type": 0,
+          "value": "firm"
+        }
+      ],
+      "type": 8,
+      "value": "b"
+    }
+  ],
+  "components.ContributeForm.developer.subTitle": [
+    {
+      "type": 0,
+      "value": "JAK MOGĘ WESPRZEĆ?"
+    }
+  ],
+  "components.ContributeForm.developer.title": [
+    {
+      "type": 0,
+      "value": "Jestem "
+    },
+    {
+      "children": [
+        {
+          "type": 0,
+          "value": "deweloperem"
+        }
+      ],
+      "type": 8,
+      "value": "b"
+    }
+  ],
+  "components.ContributeForm.text": [
+    {
+      "type": 0,
+      "value": "Ergo działa w otwartym modelu, gdzie "
+    },
+    {
+      "children": [
+        {
+          "type": 0,
+          "value": "każdy może wnieść swój wkład"
+        }
+      ],
+      "type": 8,
+      "value": "b"
+    }
+  ],
+  "components.ContributeForm.title": [
+    {
+      "type": 0,
+      "value": "Wnieś swój wkład"
+    }
+  ],
+  "components.DApps.seeAllProjects": [
+    {
+      "type": 0,
+      "value": "ZOBACZ WSZYSTKIE PROJEKTY"
+    }
+  ],
+  "components.Sigmanauts.button": [
+    {
+      "type": 0,
+      "value": "CZYTAJ WIĘCEJ & APLIKUJ"
+    }
+  ],
+  "components.Sigmanauts.button.buttonContribute": [
+    {
+      "type": 0,
+      "value": "ZASADY WSPÓŁPRACY"
+    }
+  ],
+  "components.Sigmanauts.button.discord": [
+    {
+      "type": 0,
+      "value": "DOŁĄCZ NA SERWER DISCORD"
+    }
+  ],
+  "components.Sigmanauts.button.grantsAndBounties": [
+    {
+      "type": 0,
+      "value": "DOTACJE & BONUSY"
+    }
+  ],
+  "components.Sigmanauts.button.writeAndReviewCode": [
+    {
+      "type": 0,
+      "value": "ODKRYJ ERGO"
+    }
+  ],
+  "components.Sigmanauts.formInput.button": [
+    {
+      "type": 0,
+      "value": "WYŚLIJ"
+    }
+  ],
+  "components.Sigmanauts.formInput.email": [
+    {
+      "type": 0,
+      "value": "E-Mail"
+    }
+  ],
+  "components.Sigmanauts.formInput.name": [
+    {
+      "type": 0,
+      "value": "Nazwa / Firma"
+    }
+  ],
+  "components.Sigmanauts.formInput.text": [
+    {
+      "type": 0,
+      "value": "Napisz nam o swoich sugestiach i pomysłach, porozmawiajmy!"
+    }
+  ],
+  "components.Sigmanauts.subTitle": [
+    {
+      "type": 0,
+      "value": "Seminarium szkoleniowe"
+    }
+  ],
+  "components.Sigmanauts.text": [
+    {
+      "type": 0,
+      "value": "Zgłoś się do programu szkoleniowego Sigmanautów, aby pomóc kształtować i rozwijać Ergo. "
+    },
+    {
+      "type": 1,
+      "value": "br"
+    },
+    {
+      "type": 1,
+      "value": "br"
+    },
+    {
+      "type": 0,
+      "value": "  Stwórzmy razem system finansowy-Grassroots."
+    }
+  ],
+  "components.Sigmanauts.title": [
+    {
+      "type": 0,
+      "value": "Sigmanauci"
+    }
+  ],
+  "components.Spotlight.button": [
+    {
+      "type": 0,
+      "value": "ZOBACZ WSZYSTKIE POSTY"
+    }
+  ],
+  "components.Spotlight.title": [
+    {
+      "type": 0,
+      "value": "Spotlight"
+    }
+  ],
+  "components.autolykos.button": [
+    {
+      "type": 0,
+      "value": "WYDOBYWAJ ERGO"
+    }
+  ],
+  "components.autolykos.header": [
+    {
+      "type": 0,
+      "value": "AUTOLYKOS"
+    }
+  ],
+  "components.autolykos.text": [
+    {
+      "children": [
+        {
+          "type": 0,
+          "value": "Autolykos"
+        }
+      ],
+      "type": 8,
+      "value": "b"
+    },
+    {
+      "type": 0,
+      "value": " jest zorientowanym na procesory graficzne GPU algorytmem Proof-of-Work, nie współpracującym z ASIC."
+    }
+  ],
+  "components.autolykos.title": [
+    {
+      "type": 0,
+      "value": "Przyszłość Proof of Work"
+    }
+  ],
+  "components.blogNews.end": [
+    {
+      "type": 0,
+      "value": "Nic więcej do pokazania"
+    }
+  ],
+  "components.blogNews.loading": [
+    {
+      "type": 0,
+      "value": "Ładowanie..."
+    }
+  ],
+  "components.communityHero.Discord.text": [
+    {
+      "type": 0,
+      "value": "Dołącz do nas na Discordzie!"
+    }
+  ],
+  "components.communityHero.Discord.title": [
+    {
+      "type": 0,
+      "value": "Discord"
+    }
+  ],
+  "components.communityHero.Discourse.text": [
+    {
+      "type": 0,
+      "value": "Dołącz do dyskusji na forum Ergo."
+    }
+  ],
+  "components.communityHero.Discourse.title": [
+    {
+      "type": 0,
+      "value": "Forum"
+    }
+  ],
+  "components.communityHero.Github.text": [
+    {
+      "type": 0,
+      "value": "Działajmy, zamiast tylko mówić! Oto nasz kod. W 100% open-source."
+    }
+  ],
+  "components.communityHero.Github.title": [
+    {
+      "type": 0,
+      "value": "Github"
+    }
+  ],
+  "components.communityHero.Reddit.text": [
+    {
+      "type": 0,
+      "value": "Subskrybuj nasze subreddity."
+    }
+  ],
+  "components.communityHero.Reddit.title": [
+    {
+      "type": 0,
+      "value": "Reddit"
+    }
+  ],
+  "components.communityHero.Telegram.text": [
+    {
+      "type": 0,
+      "value": "Porozmawiaj z nami na Telegramie."
+    }
+  ],
+  "components.communityHero.Telegram.title": [
+    {
+      "type": 0,
+      "value": "Telegram"
+    }
+  ],
+  "components.communityHero.Twitter.text": [
+    {
+      "type": 0,
+      "value": "Śledź nas na Twitterze."
+    }
+  ],
+  "components.communityHero.Twitter.title": [
+    {
+      "type": 0,
+      "value": "Twitter"
+    }
+  ],
+  "components.communityHero.Wiki.text": [
+    {
+      "type": 0,
+      "value": "Twoja wiki społeczności. Współtwórz w dowolnym języku!"
+    }
+  ],
+  "components.communityHero.Wiki.title": [
+    {
+      "type": 0,
+      "value": "Wiki"
+    }
+  ],
+  "components.communityHero.Youtube.text": [
+    {
+      "type": 0,
+      "value": "Subskrybuj nasz kanał na YouTube, aby otrzymywać cotygodniowe AMA, ErgoPulse i wiele więcej!"
+    }
+  ],
+  "components.communityHero.Youtube.title": [
+    {
+      "type": 0,
+      "value": "Youtube"
+    }
+  ],
+  "components.communityHero.subtitle": [
+    {
+      "type": 0,
+      "value": "GRASSROOTS FINANCE"
+    }
+  ],
+  "components.communityHero.title": [
+    {
+      "type": 0,
+      "value": "Społeczność"
+    }
+  ],
+  "components.communitySection.communityHero.linkText": [
+    {
+      "type": 0,
+      "value": "informacjami na temat współpracy"
+    }
+  ],
+  "components.communitySection.communityHero.text1": [
+    {
+      "type": 0,
+      "value": "Ergo to zdecentralizowana platforma oparta na społeczności. "
+    }
+  ],
+  "components.communitySection.communityHero.text2": [
+    {
+      "type": 0,
+      "value": "Dołącz do nas na mediach społecznościowych i zapoznaj się z "
+    }
+  ],
+  "components.communitySection.communityHero.text3": [
+    {
+      "type": 0,
+      "value": "."
+    }
+  ],
+  "components.dApps.heading": [
+    {
+      "type": 0,
+      "value": "DApps"
+    }
+  ],
+  "components.discoverErgo.text.1": [
+    {
+      "type": 0,
+      "value": "Ergo jest kolejnej generacji Proof of Work platformą smart kontraktów, która umożliwia tworzenie nowych modeli interakcji finansowych, wspartych bezpiecznym i bogatym językiem programistycznym, zbudowanym na procedurach Zero-Knowledge proofs (Σ-protocols)."
+    }
+  ],
+  "components.discoverHero.button1": [
+    {
+      "type": 0,
+      "value": "PRZECZYTAJ DOKUMENTY"
+    }
+  ],
+  "components.discoverHero.button2": [
+    {
+      "type": 0,
+      "value": "UCZ SIĘ Z DECO"
+    }
+  ],
+  "components.discoverHero.button3": [
+    {
+      "type": 0,
+      "value": "PRZECZYTAJ MANIFEST"
+    }
+  ],
+  "components.discoverHero.button4": [
+    {
+      "type": 0,
+      "value": "SPRAWDŹ BLOGA"
+    }
+  ],
+  "components.discoverHero.button5": [
+    {
+      "type": 0,
+      "value": "SKONFIGURUJ"
+    }
+  ],
+  "components.discoverHero.button6": [
+    {
+      "type": 0,
+      "value": "ODWIEDŹ ERGONAUT.SPACE"
+    }
+  ],
+  "components.discoverHero.title": [
+    {
+      "type": 0,
+      "value": "Odkryj Ergo"
+    }
+  ],
+  "components.documents.description": [
+    {
+      "type": 0,
+      "value": "Ergo stosuje podejście oparte na badaniach naukowych i wykorzystuje stabilne i dobrze przetestowane rozwiązania, aby zapewnić solidną platformę dla deweloperów do budowania na niej przez wiele lat. Większość rozwiązań Ergo jest formalizowana w dokumentach przedstawionych na konferencjach z recenzowanymi artykułami naukowymi i były szeroko omawiane w społeczności."
+    }
+  ],
+  "components.documents.heading": [
+    {
+      "type": 0,
+      "value": "Dokumenty"
+    }
+  ],
+  "components.ecosystemHero.title": [
+    {
+      "type": 0,
+      "value": "Ekosystem"
+    }
+  ],
+  "components.ergoExplorer.blockchainExplorers": [
+    {
+      "type": 0,
+      "value": "Eksploratory Blockchain"
+    }
+  ],
+  "components.ergoExplorer.button1": [
+    {
+      "type": 0,
+      "value": "EXPLORER"
+    }
+  ],
+  "components.ergoExplorer.button2": [
+    {
+      "type": 0,
+      "value": "ERGO.WATCH"
+    }
+  ],
+  "components.ergoExplorer.description": [
+    {
+      "type": 0,
+      "value": "Ergo Explorer to twój interfejs do blockchaina. Obserwuj każdą transakcję w czasie rzeczywistym. Możesz też przeglądać metryki społeczności na ergo.watch."
+    }
+  ],
+  "components.ergoExplorer.ergExplorerAltFrontend": [
+    {
+      "type": 0,
+      "value": "ErgExplorer (alternatywny frontend)"
+    }
+  ],
+  "components.ergoExplorer.ergoExplorer": [
+    {
+      "type": 0,
+      "value": "Ergo Explorer"
+    }
+  ],
+  "components.ergoExplorer.ergoWatch": [
+    {
+      "type": 0,
+      "value": "Ergo.Watch"
+    }
+  ],
+  "components.ergoExplorer.metrics": [
+    {
+      "type": 0,
+      "value": "Metryki"
+    }
+  ],
+  "components.ergoExplorer.sigmaSpaceAltBackend": [
+    {
+      "type": 0,
+      "value": "SigmaSpace (alternatywny backend)"
+    }
+  ],
+  "components.ergoRaffle.description": [
+    {
+      "type": 0,
+      "value": "ErgoRaffle to usługa crowdfundingowa zbudowana na platformie Ergo, umożliwiająca każdemu zebranie pieniędzy na projekt. Projekt ten może obejmować bezpośrednie datki na cele charytatywne, plan akademicki lub biznesowy lub cokolwiek, za co można przekonać ludzi, aby oddali swoje ciężko zarobione ERG! Dodatkowo, po zakończeniu Raffle, odbywa się loteria, a jeden szczęśliwy uczestnik wygrywa określony procent Raffle jako „nagrodę Raffle”."
+    }
+  ],
+  "components.ergoRaffle.heading": [
+    {
+      "type": 0,
+      "value": "Ergo Raffle"
+    }
+  ],
+  "components.ergofoundation.list1": [
+    {
+      "type": 0,
+      "value": "Promowanie "
+    },
+    {
+      "children": [
+        {
+          "type": 0,
+          "value": "nieprzerwanej rozbudowy "
+        }
+      ],
+      "type": 8,
+      "value": "b"
+    },
+    {
+      "type": 0,
+      "value": " protokołu Ergo Platform;"
+    }
+  ],
+  "components.ergofoundation.list2": [
+    {
+      "type": 0,
+      "value": "Popularyzacja szerokiego wdrożenia i użytkowania platformy Ergo oraz jej "
+    },
+    {
+      "children": [
+        {
+          "type": 0,
+          "value": "native token"
+        }
+      ],
+      "type": 8,
+      "value": "b"
+    },
+    {
+      "type": 0,
+      "value": " (ERG);"
+    }
+  ],
+  "components.ergofoundation.list3": [
+    {
+      "type": 0,
+      "value": "Rozwój "
+    },
+    {
+      "children": [
+        {
+          "type": 0,
+          "value": "ekosystemu"
+        }
+      ],
+      "type": 8,
+      "value": "b"
+    },
+    {
+      "type": 0,
+      "value": " wokół platformy Ergo;"
+    }
+  ],
+  "components.ergofoundation.list4": [
+    {
+      "type": 0,
+      "value": "Popularyzacja wykorzystania platformy Ergo i technologii blockchain dla "
+    },
+    {
+      "children": [
+        {
+          "type": 0,
+          "value": "dobrobytu społecznego"
+        }
+      ],
+      "type": 8,
+      "value": "b"
+    },
+    {
+      "type": 0,
+      "value": ";"
+    }
+  ],
+  "components.ergofoundation.list5": [
+    {
+      "type": 0,
+      "value": "Podtrzymywanie "
+    },
+    {
+      "children": [
+        {
+          "type": 0,
+          "value": "naprawdę zdecentralizowanej infrastruktury"
+        }
+      ],
+      "type": 8,
+      "value": "b"
+    },
+    {
+      "type": 0,
+      "value": ", i;"
+    }
+  ],
+  "components.ergofoundation.list6": [
+    {
+      "type": 0,
+      "value": "Wspieranie "
+    },
+    {
+      "children": [
+        {
+          "type": 0,
+          "value": "prywatności"
+        }
+      ],
+      "type": 8,
+      "value": "b"
+    },
+    {
+      "type": 0,
+      "value": " jako podstawowego prawa człowieka."
+    }
+  ],
+  "components.ergofoundation.title": [
+    {
+      "children": [
+        {
+          "type": 0,
+          "value": "Fundacja Ergo"
+        }
+      ],
+      "type": 8,
+      "value": "b"
+    },
+    {
+      "type": 0,
+      "value": " to entytet prowadzony przez społeczność, skupiony na"
+    }
+  ],
+  "components.exchanges.available": [
+    {
+      "type": 0,
+      "value": "Dostępne na popularnych giełdach i giełdach zdecentralizowanych."
+    }
+  ],
+  "components.exchanges.disclaimer": [
+    {
+      "type": 0,
+      "value": "Ostrzeżenie: Giełdy oferują bardzo zróżnicowane poziomy bezpieczeństwa, prywatności i kontroli nad Twoimi funduszami i informacjami. Gorąco polecamy kontrolować swoje fundusze i korzystać z jednej z powyższych opcji portfela."
+    }
+  ],
+  "components.exchanges.heading": [
+    {
+      "type": 0,
+      "value": "KUPUJ, SPRZEDAWAJ I HANDLUJ ERGO"
+    }
+  ],
+  "components.exchanges.subheading": [
+    {
+      "type": 0,
+      "value": "Giełdy"
+    }
+  ],
+  "components.explore.description": [
+    {
+      "type": 0,
+      "value": "Ergo Explorer to twój interfejs z blockchain. Oglądaj każdą transakcję w czasie rzeczywistym. Lub przeglądaj społecznościowe metryki na ergo.watch."
+    }
+  ],
+  "components.explore.heading": [
+    {
+      "type": 0,
+      "value": "Eksploruj"
+    }
+  ],
+  "components.explore.subheading": [
+    {
+      "type": 0,
+      "value": "ZANURZ SIĘ W ŚWIECIE TRANSAKCJI ERGO"
+    }
+  ],
+  "components.faq.anyQuestions": [
+    {
+      "type": 0,
+      "value": "MASZ PYTANIA?"
+    }
+  ],
+  "components.faq.description": [
+    {
+      "type": 0,
+      "value": "Zebraliśmy najczęściej zadawane pytania."
+    }
+  ],
+  "components.faq.heading": [
+    {
+      "type": 0,
+      "value": "Najczęściej zadawane pytania"
+    }
+  ],
+  "components.faq.loading": [
+    {
+      "type": 0,
+      "value": "Ładowanie..."
+    }
+  ],
+  "components.faq.text.2": [
+    {
+      "type": 0,
+      "value": "NIE MOŻESZ ZNALEŹĆ TEGO, "
+    },
+    {
+      "type": 1,
+      "value": "breakingLine"
+    },
+    {
+      "type": 0,
+      "value": " CZEGO SZUKASZ?"
+    }
+  ],
+  "components.favorites.button1": [
+    {
+      "type": 0,
+      "value": "ODKRYJ ERGO RAFFLE"
+    }
+  ],
+  "components.favorites.mewFund": [
+    {
+      "type": 0,
+      "value": "WYPRÓBUJ MEWFUND"
+    }
+  ],
+  "components.favorites.raffleV2": [
+    {
+      "type": 0,
+      "value": "PRZECZYTAJ O RAFFLE V2"
+    }
+  ],
+  "components.featureCard.noImage": [
+    {
+      "type": 0,
+      "value": "Brak obrazu"
+    }
+  ],
+  "components.getErg.BuyIt.text": [
+    {
+      "type": 0,
+      "value": "Dostępne na popularnych giełdach zdecentralizowanych i scentralizowanych."
+    }
+  ],
+  "components.getErg.BuyIt.title": [
+    {
+      "type": 0,
+      "value": "Giełdy"
+    }
+  ],
+  "components.getErg.MineIt.text": [
+    {
+      "type": 0,
+      "value": "Autolykos, algorytm ASIC-resistant & fair mined Proof-of-Work przyjazny dla zwykłych GPU."
+    }
+  ],
+  "components.getErg.MineIt.title": [
+    {
+      "type": 0,
+      "value": "Wydobywaj"
+    }
+  ],
+  "components.getErg.StoreIt.text": [
+    {
+      "type": 0,
+      "value": "Proste i bezpieczne portfele nienadzorowane do przechowywania twoich ERG w bezpieczeństwie."
+    }
+  ],
+  "components.getErg.StoreIt.title": [
+    {
+      "type": 0,
+      "value": "Portfele"
+    }
+  ],
+  "components.getErg.UseIt.text": [
+    {
+      "type": 0,
+      "value": "Wykorzystaj swoje ERG już dziś w naszym rozwijającym się ekosystemie."
+    }
+  ],
+  "components.getErg.UseIt.title": [
+    {
+      "type": 0,
+      "value": "Ekosystem"
+    }
+  ],
+  "components.getErg.description": [
+    {
+      "type": 0,
+      "value": "Ergo oferuje bogaty ekosystem dla developerów, górników i inwestorów. Mamy wszystko, czego potrzebujesz."
+    }
+  ],
+  "components.getErg.heroTitle": [
+    {
+      "type": 0,
+      "value": "NIEPOWSTRZYMANE DEFI"
+    }
+  ],
+  "components.getErg.title": [
+    {
+      "type": 0,
+      "value": "Zdobądź ERG"
+    }
+  ],
+  "components.grantsAndBounties.button1": [
+    {
+      "type": 0,
+      "value": "BONUSY"
+    }
+  ],
+  "components.grantsAndBounties.button2": [
+    {
+      "type": 0,
+      "value": "ROZPOCZNIJ ZBIÓRKĘ"
+    }
+  ],
+  "components.grantsAndBounties.button3": [
+    {
+      "type": 0,
+      "value": "SKONTAKTUJ SIĘ Z NAMI"
+    }
+  ],
+  "components.grantsAndBounties.description": [
+    {
+      "type": 0,
+      "value": "W ogólnym przypadku, wszystko co jest edukacyjne dla społeczności jest przedmiotem jakiejś nagrody, nawet jeśli nie jest to specjalnie wymienione. Szukamy projektów, które skupiają się na budowaniu kluczowej infrastruktury ekosystemu. Jednak najszybszym sposobem na zdobycie funduszy jest rozpoczęcie losowania."
+    }
+  ],
+  "components.grantsAndBounties.heading": [
+    {
+      "type": 0,
+      "value": "Dotacje i nagrody"
+    }
+  ],
+  "components.hallOfFame.description1": [
+    {
+      "type": 0,
+      "value": "Ergo zostało założone przez zespół, który ma solidne doświadczenie w podstawowej pracy przy kryptowalutach i frameworkach blockchain, w tym NXT, Scorex, Cardano i Waves. Poniżej znajdują się krótkie biografie niektórych członków zespołu ERGO oraz wielu innych deweloperów i członków społeczności, z których niektórzy pozostają anonimowi."
+    }
+  ],
+  "components.hallOfFame.description2": [
+    {
+      "type": 0,
+      "value": "Ergo jest wynikiem pracy społeczności, a większość członków zespołu (a nawet członków fundacji) zaczynała jako członkowie społeczności. Na dole strony znajduje się krótki opis oraz informacje na temat Fundacji Ergo."
+    }
+  ],
+  "components.hallOfFame.tab1": [
+    {
+      "type": 0,
+      "value": "PODSTAWOWI"
+    }
+  ],
+  "components.hallOfFame.tab2": [
+    {
+      "type": 0,
+      "value": "SPOŁECZNOŚĆ"
+    }
+  ],
+  "components.hallOfFame.tab3": [
+    {
+      "type": 0,
+      "value": "FUNDACJA"
+    }
+  ],
+  "components.hallOfFame.title": [
+    {
+      "type": 0,
+      "value": "Galeria Sław"
+    }
+  ],
+  "components.highlights.slide.1.quote": [
+    {
+      "type": 0,
+      "value": "95,57% "
+    },
+    {
+      "type": 1,
+      "value": "breakingLine"
+    },
+    {
+      "type": 0,
+      "value": "Publiczna alokacja"
+    }
+  ],
+  "components.highlights.slide.1.text": [
+    {
+      "type": 0,
+      "value": "Podczas startu Ergo w 2019 roku nie było żadnej oferty początkowej monet, nie było również żadnych pre-mine ani pre-alokacji tokenów dla członków zespołu lub venture capitalist. To naprawdę sprawiedliwe uruchomienie z 4,43% środków przeznaczonych na rozwój ekosystemu. Bezprecedensowe w jakiejkolwiek innej platformie smart-contract."
+    }
+  ],
+  "components.highlights.slide.1.title": [
+    {
+      "type": 0,
+      "value": "Sprawiedliwy start"
+    }
+  ],
+  "components.highlights.slide.2.quote": [
+    {
+      "type": 0,
+      "value": "TRUE P2P"
+    }
+  ],
+  "components.highlights.slide.2.text": [
+    {
+      "type": 0,
+      "value": "Umożliwia bardziej innowacyjne, ukierunkowane implementacje, których nie można zrealizować w konwencjonalnym bankowości. Ergo oferuje potężne narzędzia z zasilanymi inteligentnymi kontraktami obiektami mikrokredytowymi i systemami lokalnego wymiany handlowej (LETS)."
+    }
+  ],
+  "components.highlights.slide.2.title": [
+    {
+      "type": 0,
+      "value": "Alternatywna ekonomia"
+    }
+  ],
+  "components.highlights.slide.3.quote": [
+    {
+      "type": 0,
+      "value": "Σ-protokoły"
+    }
+  ],
+  "components.highlights.slide.3.text": [
+    {
+      "type": 0,
+      "value": "Prywatność musi pozostać opcją w celu ochrony autonomii. Prywatność to możliwość tworzenia barier i budowania granic, aby stworzyć przestrzeń dla jednostki. To zależy od każdego, jakie granice i barierki chce stworzyć. To umożliwia nowe modele interakcji finansowych, oparte na bezpiecznym i bogatym języku skryptowym ErgoScript oraz elastycznych i potężnych dowodach zero-wiedzy."
+    }
+  ],
+  "components.highlights.slide.3.title": [
+    {
+      "type": 0,
+      "value": "Opcjonalna prywatność"
+    }
+  ],
+  "components.highlights.title": [
+    {
+      "type": 0,
+      "value": "HIGHLIGHTS"
+    }
+  ],
+  "components.homeHero.button": [
+    {
+      "type": 0,
+      "value": "SPRAWDŹ"
+    }
+  ],
+  "components.homeHero.pitchDeckButton": [
+    {
+      "type": 0,
+      "value": "PREZENTACJA"
+    }
+  ],
+  "components.homeHero.text": [
+    {
+      "type": 0,
+      "value": "Ergo to platforma smart kontraktów nowej generacji, która zapewnia wolność finansową zwykłych ludzi poprzez bezpieczne, dostępne i zdecentralizowane narzędzie finansowe."
+    }
+  ],
+  "components.homeHero.title": [
+    {
+      "type": 0,
+      "value": "Kreowanie przyszłości finansów"
+    }
+  ],
+  "components.homeInfo.blockReward": [
+    {
+      "type": 0,
+      "value": "NAGRODA ZA BLOK"
+    }
+  ],
+  "components.homeInfo.circulatingSupply": [
+    {
+      "type": 0,
+      "value": "PODAŻ W OBIEGU"
+    }
+  ],
+  "components.homeInfo.hashRate": [
+    {
+      "type": 0,
+      "value": "HASH RATE"
+    }
+  ],
+  "components.homeInfo.transactionPerDay": [
+    {
+      "type": 0,
+      "value": "TRANSAKCJE NA DZIEŃ"
+    }
+  ],
+  "components.learn.description": [
+    {
+      "type": 0,
+      "value": "Zacznij od podstaw. Czym jest Ergo? Co możesz zrobić na Ergo?"
+    }
+  ],
+  "components.learn.heading": [
+    {
+      "type": 0,
+      "value": "Dowiedz się więcej"
+    }
+  ],
+  "components.mining.button1": [
+    {
+      "type": 0,
+      "value": "DOKUMENTACJA"
+    }
+  ],
+  "components.mining.button2": [
+    {
+      "type": 0,
+      "value": "STATYSTYKI PULI WYDOBYWCZEJ"
+    }
+  ],
+  "components.mining.button3": [
+    {
+      "type": 0,
+      "value": "DISCORD"
+    }
+  ],
+  "components.mining.button4": [
+    {
+      "type": 0,
+      "value": "SUBREDDIT"
+    }
+  ],
+  "components.mining.button5": [
+    {
+      "type": 0,
+      "value": "WPISY NA BLOGU O WYDOBYCIU"
+    }
+  ],
+  "components.mining.button6": [
+    {
+      "type": 0,
+      "value": "EMISJA I TOKENOMIA"
+    }
+  ],
+  "components.mining.calculator.currentBlockReward": [
+    {
+      "type": 0,
+      "value": "Aktualna nagroda za blok"
+    }
+  ],
+  "components.mining.calculator.currentPrice": [
+    {
+      "type": 0,
+      "value": "Aktualna cena"
+    }
+  ],
+  "components.mining.calculator.description": [
+    {
+      "type": 0,
+      "value": "Autolykos to podstawowy algorytm Proof of Work (PoW) odporny na ASIC i przyjazny dla GPU."
+    }
+  ],
+  "components.mining.calculator.hash": [
+    {
+      "type": 0,
+      "value": "Twój hashrate"
+    }
+  ],
+  "components.mining.calculator.mhs": [
+    {
+      "type": 0,
+      "value": "MH/s"
+    }
+  ],
+  "components.mining.calculator.networkHashrate": [
+    {
+      "type": 0,
+      "value": "Hashrate sieci"
+    }
+  ],
+  "components.mining.calculator.placeholder": [
+    {
+      "type": 0,
+      "value": "Wartość hashrate"
+    }
+  ],
+  "components.mining.calculator.rev": [
+    {
+      "type": 0,
+      "value": "Dzienny przychód"
+    }
+  ],
+  "components.mining.calculator.ths": [
+    {
+      "type": 0,
+      "value": "TH/s"
+    }
+  ],
+  "components.mining.calculator.title": [
+    {
+      "type": 0,
+      "value": "Kalkulator wydobycia"
+    }
+  ],
+  "components.mining.minersTitle": [
+    {
+      "type": 0,
+      "value": "Górnicy"
+    }
+  ],
+  "components.mining.miningPoolsTitle": [
+    {
+      "type": 0,
+      "value": "Pule wydobywcze"
+    }
+  ],
+  "components.mining.text.1": [
+    {
+      "type": 0,
+      "value": "Wydobywanie Ergo opiera się na algorytmie Proof of Work Autolykos, odpornym na układy ASIC, zaprogramowanym w Scali. Wydobywanie możliwe jest na większości układów GPU w stosunkowo niższych temperaturach niż inne algorytmy, co zwiększa żywotność sprzętu górniczego. W połączeniu z modelem eUTXO i przeniesieniem cięższych obliczeń poza łańcuch, tworzy wysoce wydajny Proof of Work."
+    }
+  ],
+  "components.mining.text.2": [
+    {
+      "type": 0,
+      "value": "Witamy w przyszłości Proof of Work."
+    }
+  ],
+  "components.mining.text.3": [
+    {
+      "type": 0,
+      "value": "Na początku zapoznaj się z tworzonym przez społeczność przewodnikiem dotyczącym górnictwa lub dołącz do dyskusji na jego temat."
+    }
+  ],
+  "components.mining.title": [
+    {
+      "type": 0,
+      "value": "Wydobycie"
+    }
+  ],
+  "components.news.blog": [
+    {
+      "type": 0,
+      "value": "Blog"
+    }
+  ],
+  "components.news.latest": [
+    {
+      "type": 0,
+      "value": "najnowsze wiadomości"
+    }
+  ],
+  "components.news.latestAria": [
+    {
+      "type": 0,
+      "value": "Najnowsze wiadomości"
+    }
+  ],
+  "components.news.newBadge": [
+    {
+      "type": 0,
+      "value": "Nowe"
+    }
+  ],
+  "components.news.none": [
+    {
+      "type": 0,
+      "value": "Brak dostępnych wiadomości."
+    }
+  ],
+  "components.news.title": [
+    {
+      "type": 0,
+      "value": "Wiadomości"
+    }
+  ],
+  "components.news.viewAll": [
+    {
+      "type": 0,
+      "value": "Zobacz wszystkie wiadomości"
+    }
+  ],
+  "components.ourFavorites.heading": [
+    {
+      "type": 0,
+      "value": "NASZE ULUBIONE"
+    }
+  ],
+  "components.ourmission.description": [
+    {
+      "type": 0,
+      "value": "Fundacja Ergo zobowiązuje się do organicznego i nieprzerwanego rozwoju protokołu platformy Ergo."
+    }
+  ],
+  "components.ourmission.emissionAndTokenomics": [
+    {
+      "type": 0,
+      "value": "EMISJA I TOKENOMIKA"
+    }
+  ],
+  "components.ourmission.ergofoundation": [
+    {
+      "type": 0,
+      "value": "FUNDACJA ERGO"
+    }
+  ],
+  "components.ourmission.reachus.twitter": [
+    {
+      "type": 0,
+      "value": "SKONTAKTUJ SIĘ Z NAMI NA TWITTERZE"
+    }
+  ],
+  "components.ourmission.subdescription": [
+    {
+      "type": 0,
+      "value": "Fundacja Ergo zobowiązuje się do podejmowania działań mających na celu maksymalizację liczby wartościowych projektów ekosystemowych realizowanych w sposób open-source, z jak najmniej restrykcyjną licencją."
+    }
+  ],
+  "components.ourmission.title": [
+    {
+      "type": 0,
+      "value": "Nasza misja"
+    }
+  ],
+  "components.partners.title": [
+    {
+      "type": 0,
+      "value": "Partnerzy"
+    }
+  ],
+  "components.post.translate": [
+    {
+      "type": 0,
+      "value": "Przetłumacz"
+    }
+  ],
+  "components.roadmap.coinmarketcal": [
+    {
+      "type": 0,
+      "value": "ZOBACZ WIĘCEJ NA COINMARKETCAL"
+    }
+  ],
+  "components.roadmap.description": [
+    {
+      "type": 0,
+      "value": "Zauważ, że Ergo to platforma. Wiele z projektów wymienionych poniżej nie ma formalnego związku z Fundacją Ergo lub ze sobą nawzajem."
+    }
+  ],
+  "components.roadmap.section1.title": [
+    {
+      "type": 0,
+      "value": "DO TEJ PORY"
+    }
+  ],
+  "components.roadmap.section2.title": [
+    {
+      "type": 0,
+      "value": "EKOSYSTEM"
+    }
+  ],
+  "components.roadmap.section3.title": [
+    {
+      "type": 0,
+      "value": "W TRAKCIE"
+    }
+  ],
+  "components.roadmap.section4.title": [
+    {
+      "type": 0,
+      "value": "WKRÓTCE"
+    }
+  ],
+  "components.roadmap.title": [
+    {
+      "type": 0,
+      "value": "Roadmap"
+    }
+  ],
+  "components.software.description": [
+    {
+      "type": 0,
+      "value": "Ergo Node to Twoje wejście do rozwoju na Ergo i umożliwia komunikację z blockchainem."
+    }
+  ],
+  "components.software.heading": [
+    {
+      "type": 0,
+      "value": "Oprogramowanie"
+    }
+  ],
+  "components.uniqueErgo.card1.button": [
+    {
+      "type": 0,
+      "value": "POZNAJ"
+    }
+  ],
+  "components.uniqueErgo.card1.text": [
+    {
+      "type": 0,
+      "value": "Ergo czerpie z dziesięciu lat rozwoju technologii blockchain, łącząc sprawdzone i testowane zasady z najlepszymi badaniami akademickimi z dziedziny kryptografii, modeli konsensusu i walut cyfrowych. Rozpoczynamy od solidnych podstaw technologii blockchain i wprowadzamy nowe i potężne kryptografie."
+    }
+  ],
+  "components.uniqueErgo.card1.title": [
+    {
+      "type": 0,
+      "value": "OPARTY NA BADANIACH I SKIEROWANY NA ŚWIAT RZECZYWISTY"
+    }
+  ],
+  "components.uniqueErgo.card2.button": [
+    {
+      "type": 0,
+      "value": "POZNAJ"
+    }
+  ],
+  "components.uniqueErgo.card2.text": [
+    {
+      "type": 0,
+      "value": "Ergo zapewnia lepsze wsparcie dla rzeczywistych umów finansowych. Ergo obsługuje wszechstronne dAppy, które działają przewidywalnie, znanym kosztem i nie mają żadnego niebezpieczeństwa związanego z nieograniczoną funkcjonalnością. Smart kontrakty Ergo pozwalają nam wykonywać różnorodne zadania i mogą być zupełnie Turing complete, ale zawsze z góry wiemy, ile kosztuje kod i czy zostanie wykonany pomyślnie."
+    }
+  ],
+  "components.uniqueErgo.card2.title": [
+    {
+      "type": 0,
+      "value": "POTĘŻNY I BEZPIECZNY"
+    }
+  ],
+  "components.uniqueErgo.card3.button": [
+    {
+      "type": 0,
+      "value": "POZNAJ"
+    }
+  ],
+  "components.uniqueErgo.card3.text": [
+    {
+      "type": 0,
+      "value": "Protokoły Sigma (Σ-Protokoły) są podstawą smart kontraktów Ergo. Pozwalają one na klasę wydajnych protokołów zerowej wiedzy, które umożliwiają nam implementację złożonych zadań, które w przeciwnym razie byłby niemożliwe, ryzykowne lub kosztowne. Witaj w prywatności poziomu aplikacji typu self-sovereign: bezpieczne skrypty, które można używać do uzyskania dostępu do mikserów lub innej funkcjonalności bez potrzeby trzeciej strony."
+    }
+  ],
+  "components.uniqueErgo.card3.title": [
+    {
+      "type": 0,
+      "value": "INTELIGENTNY I PROSTY"
+    }
+  ],
+  "components.uniqueErgo.card4.button": [
+    {
+      "type": 0,
+      "value": "POZNAJ"
+    }
+  ],
+  "components.uniqueErgo.card4.text": [
+    {
+      "type": 0,
+      "value": "Zwykli użytkownicy, którzy nie uruchamiają pełnego węzła, powinni korzystać z takich samych korzyści związanych z bezpieczeństwem, jak górnicy. Nieinteraktywne dowody Proof-of-Work (NIPOPOW) pozwalają nam na dokonywanie i weryfikowanie transakcji z pełnym zaufaniem, bez potrzeby pobierania całego blockchain i zajmowania miejsca na dysku, przepustowości i czasu. Wymagane jest zaledwie 1 MB danych, co oznacza, że można z niej korzystać na każdym urządzeniu."
+    }
+  ],
+  "components.uniqueErgo.card4.title": [
+    {
+      "type": 0,
+      "value": "BEZPIECZNE I DOSTĘPNE"
+    }
+  ],
+  "components.uniqueErgo.title": [
+    {
+      "type": 0,
+      "value": "CO CZYNI ERGO UNIKALNYM"
+    }
+  ],
+  "components.usingErg.BuyIt.text": [
+    {
+      "type": 0,
+      "value": "Dostępne na popularnych centralizowanych i zdecentralizowanych giełdach."
+    }
+  ],
+  "components.usingErg.BuyIt.title": [
+    {
+      "type": 0,
+      "value": "Giełdy"
+    }
+  ],
+  "components.usingErg.MineIt.text": [
+    {
+      "type": 0,
+      "value": "Autolykos to algorytm Proof-of-Work, który jest oporny na ASIC i przyjazny dla popularnych kart graficznych."
+    }
+  ],
+  "components.usingErg.MineIt.title": [
+    {
+      "type": 0,
+      "value": "Wydobywaj"
+    }
+  ],
+  "components.usingErg.StoreIt.text": [
+    {
+      "type": 0,
+      "value": "Proste i bezpieczne portfele nienadzorowane do przechowywania twoich ERG w bezpieczeństwie."
+    }
+  ],
+  "components.usingErg.StoreIt.title": [
+    {
+      "type": 0,
+      "value": "Portfele"
+    }
+  ],
+  "components.usingErg.UseIt.title": [
+    {
+      "type": 0,
+      "value": "Wykorzystaj swoje ERG już dziś w naszym rozwijającym się ekosystemie."
+    }
+  ],
+  "components.usingErg.description": [
+    {
+      "type": 0,
+      "value": "Ergo ma bogaty ekosystem rozwijający się na jego podstawie. Niezależnie od tego, czy jesteś deweloperem, górnikiem, czy inwestorem - mamy dla Ciebie wiele możliwości."
+    }
+  ],
+  "components.usingErg.subtitle": [
+    {
+      "type": 0,
+      "value": "NIEROZŁAMALNY DEFI"
+    }
+  ],
+  "components.usingErg.title": [
+    {
+      "type": 0,
+      "value": "ZDOBĄDŹ ERG"
+    }
+  ],
+  "components.wallets.ErgoPay": [
+    {
+      "type": 0,
+      "value": "ErgoPay"
+    }
+  ],
+  "components.wallets.chooseYours": [
+    {
+      "type": 0,
+      "value": "WYBIERZ SWÓJ"
+    }
+  ],
+  "components.wallets.coldStorageHeader": [
+    {
+      "type": 0,
+      "value": "Przechowywanie offline"
+    }
+  ],
+  "components.wallets.dAppConnectorHeader": [
+    {
+      "type": 0,
+      "value": "Łącznik dApp"
+    }
+  ],
+  "components.wallets.featureHeader": [
+    {
+      "type": 0,
+      "value": "Cechy"
+    }
+  ],
+  "components.wallets.hotStorageHeader": [
+    {
+      "type": 0,
+      "value": "Przechowywanie online"
+    }
+  ],
+  "components.wallets.mobileAppHeader": [
+    {
+      "type": 0,
+      "value": "Aplikacja mobilna"
+    }
+  ],
+  "components.wallets.setupGuides": [
+    {
+      "type": 0,
+      "value": "PRZEWODNIKI KONFIGURACYJNE"
+    }
+  ],
+  "components.wallets.walletDescription1": [
+    {
+      "type": 0,
+      "value": "Cyfrowe portfele mogą pomóc w bezpiecznym przechowywaniu Twoich kryptowalut, zapewniając prywatność i kontrolę."
+    }
+  ],
+  "components.wallets.walletDescription2": [
+    {
+      "type": 0,
+      "value": "Należy pamiętać, że portfele są obsługiwane przez strony trzecie. Poniżej podajemy jedynie informacje na temat portfeli jako uprzejmość, w celu ułatwienia doświadczenia związanego z kryptowalutami."
+    }
+  ],
+  "components.wallets.walletsHeader": [
+    {
+      "type": 0,
+      "value": "Portfele"
+    }
+  ],
+  "components.wallets.walletsTitle": [
+    {
+      "type": 0,
+      "value": "Portfele"
+    }
+  ],
+  "components.wiki.description": [
+    {
+      "type": 0,
+      "value": "ergonaut.space to nasze wiki prowadzone przez społeczność! Pełna wspaniałych informacji na temat podstawowych szczegółów technicznych blockchaina Ergo, łatwo zrozumiałych dla osób nie technicznych. Znajdziesz tam również wiele przewodników, samouczków i treści przesłanych przez użytkowników. Utwórz konto, aby zacząć przyczyniać się do wiki!"
+    }
+  ],
+  "components.wiki.description.short": [
+    {
+      "type": 0,
+      "value": "ergonaut.space to wiki społeczności blockchaina Ergo, przewodnik tłumaczący, jak korzystać i podstawowe szczegóły techniczne blockchaina Ergo w łatwy sposób zrozumiały dla osób nie technicznych."
+    }
+  ],
+  "components.wiki.heading": [
+    {
+      "type": 0,
+      "value": "Wiki"
+    }
+  ],
+  "footer.blog.title": [
+    {
+      "type": 0,
+      "value": "BLOG"
+    }
+  ],
+  "footer.community.1": [
+    {
+      "type": 0,
+      "value": "Dołącz na nasze kanały"
+    }
+  ],
+  "footer.community.2": [
+    {
+      "type": 0,
+      "value": "Sigmanauci"
+    }
+  ],
+  "footer.community.3": [
+    {
+      "type": 0,
+      "value": "Współtwórz Ergo"
+    }
+  ],
+  "footer.community.4": [
+    {
+      "type": 0,
+      "value": "Galeria sław"
+    }
+  ],
+  "footer.community.5": [
+    {
+      "type": 0,
+      "value": "Fundacja Ergo"
+    }
+  ],
+  "footer.community.title": [
+    {
+      "type": 0,
+      "value": "SPOŁECZNOŚĆ"
+    }
+  ],
+  "footer.discover.1": [
+    {
+      "type": 0,
+      "value": "Publikacje oprogramowania"
+    }
+  ],
+  "footer.discover.2": [
+    {
+      "type": 0,
+      "value": "Dotacje & Bonusy"
+    }
+  ],
+  "footer.discover.3": [
+    {
+      "type": 0,
+      "value": "FAQ"
+    }
+  ],
+  "footer.discover.4": [
+    {
+      "type": 0,
+      "value": "Eksploruj"
+    }
+  ],
+  "footer.discover.5": [
+    {
+      "type": 0,
+      "value": "Dokumenty"
+    }
+  ],
+  "footer.discover.discoverErg": [
+    {
+      "type": 0,
+      "value": "ODKRYJ ERG"
+    }
+  ],
+  "footer.discover.softwareReleases": [
+    {
+      "type": 0,
+      "value": "Wydania oprogramowania"
+    }
+  ],
+  "footer.discover.title": [
+    {
+      "type": 0,
+      "value": "ODKRYJ"
+    }
+  ],
+  "footer.ecosystem.1": [
+    {
+      "type": 0,
+      "value": "DApps"
+    }
+  ],
+  "footer.ecosystem.2": [
+    {
+      "type": 0,
+      "value": "Roadmap"
+    }
+  ],
+  "footer.ecosystem.3": [
+    {
+      "type": 0,
+      "value": "Wiki"
+    }
+  ],
+  "footer.ecosystem.4": [
+    {
+      "type": 0,
+      "value": "Ergo Raffle"
+    }
+  ],
+  "footer.ecosystem.5": [
+    {
+      "type": 0,
+      "value": "Podkasty"
+    }
+  ],
+  "footer.ecosystem.title": [
+    {
+      "type": 0,
+      "value": "EKOSYSTEM"
+    }
+  ],
+  "footer.favorites.title": [
+    {
+      "type": 0,
+      "value": "NASZE ULUBIONE"
+    }
+  ],
+  "footer.getErg.1": [
+    {
+      "type": 0,
+      "value": "Wydobywanie"
+    }
+  ],
+  "footer.getErg.2": [
+    {
+      "type": 0,
+      "value": "Kalkulator wydobycia"
+    }
+  ],
+  "footer.getErg.3": [
+    {
+      "type": 0,
+      "value": "Portfele"
+    }
+  ],
+  "footer.getErg.4": [
+    {
+      "type": 0,
+      "value": "Giełdy"
+    }
+  ],
+  "footer.getErg.title": [
+    {
+      "type": 0,
+      "value": "ZDOBĄDŹ ERG"
+    }
+  ],
+  "footer.legal": [
+    {
+      "type": 0,
+      "value": "Informacje prawne"
+    }
+  ],
+  "footer.news.title": [
+    {
+      "type": 0,
+      "value": "NOWOŚCI"
+    }
+  ],
+  "footer.privacyPolicy": [
+    {
+      "type": 0,
+      "value": "Polityka prywatności"
+    }
+  ],
+  "footer.realLifeErgo.title": [
+    {
+      "type": 0,
+      "value": "Ergo w prawdziwym życiu"
+    }
+  ],
+  "footer.weGotIt": [
+    {
+      "type": 0,
+      "value": "Mamy to!"
+    }
+  ],
+  "hallOfFame.title": [
+    {
+      "type": 0,
+      "value": "Galeria Sław"
+    }
+  ],
+  "navigation.discover": [
+    {
+      "type": 0,
+      "value": "ODKRYJ"
+    }
+  ],
+  "navigation.ecosystem": [
+    {
+      "type": 0,
+      "value": "EKOSYSTEM"
+    }
+  ],
+  "navigation.ergoCommunity": [
+    {
+      "type": 0,
+      "value": "SPOŁECZNOŚĆ"
+    }
+  ],
+  "navigation.getErg": [
+    {
+      "type": 0,
+      "value": "ZDOBĄDŹ ERG"
+    }
+  ],
+  "navigation.moreContent": [
+    {
+      "type": 0,
+      "value": "Więcej treści?"
+    }
+  ],
+  "pages.404.hero": [
+    {
+      "type": 0,
+      "value": "404. Nie znaleziono strony."
+    }
+  ],
+  "pages.404.title": [
+    {
+      "type": 0,
+      "value": "Nie znaleziono"
+    }
+  ],
+  "pages.blog.title": [
+    {
+      "type": 0,
+      "value": "Blog"
+    }
+  ],
+  "pages.community.title": [
+    {
+      "type": 0,
+      "value": "Społeczność"
+    }
+  ],
+  "pages.discover.title": [
+    {
+      "type": 0,
+      "value": "Odkryj"
+    }
+  ],
+  "pages.ecosystem.title": [
+    {
+      "type": 0,
+      "value": "Ekosystem"
+    }
+  ],
+  "pages.get-erg.title": [
+    {
+      "type": 0,
+      "value": "Zdobądź ERG"
+    }
+  ],
+  "pages.home.title": [
+    {
+      "type": 0,
+      "value": "Strona główna"
+    }
+  ],
+  "pages.legal.title": [
+    {
+      "type": 0,
+      "value": "Informacje prawne"
+    }
+  ],
+  "pages.media.title": [
+    {
+      "type": 0,
+      "value": "Media o nas"
+    }
+  ],
+  "pages.mobile-wallets": [
+    {
+      "type": 0,
+      "value": "Portfele mobilne"
+    }
+  ],
+  "pages.news.title": [
+    {
+      "type": 0,
+      "value": "Wiadomości"
+    }
+  ],
+  "pages.privacyPolicy.title": [
+    {
+      "type": 0,
+      "value": "Polityka prywatności"
+    }
+  ],
+  "routeSpinner.translating": [
+    {
+      "type": 0,
+      "value": "Tłumaczenie"
+    }
+  ],
+  "routeSpinner.translatingEllipsis": [
+    {
+      "type": 0,
+      "value": "Tłumaczenie..."
+    }
+  ],
+  "secondaryMenu.blog": [
+    {
+      "type": 0,
+      "value": "BLOG"
+    }
+  ],
+  "secondaryMenu.documentation": [
+    {
+      "type": 0,
+      "value": "DOKUMENTACJA"
+    }
+  ],
+  "secondaryMenu.exchanges": [
+    {
+      "type": 0,
+      "value": "GIEŁDY"
+    }
+  ],
+  "secondaryMenu.roadmap": [
+    {
+      "type": 0,
+      "value": "ROADMAP"
+    }
+  ],
+  "secondaryMenu.sigmaverse": [
+    {
+      "type": 0,
+      "value": "SIGMAVERSE"
+    }
+  ],
+  "secondaryMenu.wallets": [
+    {
+      "type": 0,
+      "value": "PORTFELE"
+    }
+  ]
+}

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+/// <reference path="./.next/types/routes.d.ts" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.

--- a/next.config.js
+++ b/next.config.js
@@ -62,7 +62,7 @@ const nextConfig = {
       },
       {
         source: '/hall_of_fame/',
-        destination: '/community/#HallOfFame',
+        destination: '/hall-of-fame',
         permanent: true,
       },
       {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1641,6 +1641,7 @@
       "resolved": "https://registry.npmjs.org/@isaacs/balanced-match/-/balanced-match-4.0.1.tgz",
       "integrity": "sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": "20 || >=22"
       }
@@ -1650,6 +1651,7 @@
       "resolved": "https://registry.npmjs.org/@isaacs/brace-expansion/-/brace-expansion-5.0.0.tgz",
       "integrity": "sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@isaacs/balanced-match": "^4.0.1"
       },
@@ -1937,9 +1939,10 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "15.4.7",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.4.7.tgz",
-      "integrity": "sha512-PrBIpO8oljZGTOe9HH0miix1w5MUiGJ/q83Jge03mHEE0E3pyqzAy2+l5G6aJDbXoobmxPJTVhbCuwlLtjSHwg=="
+      "version": "15.5.9",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.5.9.tgz",
+      "integrity": "sha512-4GlTZ+EJM7WaW2HEZcyU317tIQDjkQIyENDLxYJfSWlfqguN+dHkZgyQTV/7ykvobU7yEH5gKvreNrH4B6QgIg==",
+      "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
       "version": "12.3.1",
@@ -1980,12 +1983,13 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "15.4.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.4.7.tgz",
-      "integrity": "sha512-2Dkb+VUTp9kHHkSqtws4fDl2Oxms29HcZBwFIda1X7Ztudzy7M6XF9HDS2dq85TmdN47VpuhjE+i6wgnIboVzQ==",
+      "version": "15.5.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.5.7.tgz",
+      "integrity": "sha512-IZwtxCEpI91HVU/rAUOOobWSZv4P2DeTtNaCdHqLcTJU4wdNXgAySvKa/qJCgR5m6KI8UsKDXtO2B31jcaw1Yw==",
       "cpu": [
         "arm64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -1995,12 +1999,13 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "15.4.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.4.7.tgz",
-      "integrity": "sha512-qaMnEozKdWezlmh1OGDVFueFv2z9lWTcLvt7e39QA3YOvZHNpN2rLs/IQLwZaUiw2jSvxW07LxMCWtOqsWFNQg==",
+      "version": "15.5.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.5.7.tgz",
+      "integrity": "sha512-UP6CaDBcqaCBuiq/gfCEJw7sPEoX1aIjZHnBWN9v9qYHQdMKvCKcAVs4OX1vIjeE+tC5EIuwDTVIoXpUes29lg==",
       "cpu": [
         "x64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -2010,12 +2015,13 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "15.4.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.4.7.tgz",
-      "integrity": "sha512-ny7lODPE7a15Qms8LZiN9wjNWIeI+iAZOFDOnv2pcHStncUr7cr9lD5XF81mdhrBXLUP9yT9RzlmSWKIazWoDw==",
+      "version": "15.5.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.5.7.tgz",
+      "integrity": "sha512-NCslw3GrNIw7OgmRBxHtdWFQYhexoUCq+0oS2ccjyYLtcn1SzGzeM54jpTFonIMUjNbHmpKpziXnpxhSWLcmBA==",
       "cpu": [
         "arm64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -2025,12 +2031,13 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "15.4.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.4.7.tgz",
-      "integrity": "sha512-4SaCjlFR/2hGJqZLLWycccy1t+wBrE/vyJWnYaZJhUVHccpGLG5q0C+Xkw4iRzUIkE+/dr90MJRUym3s1+vO8A==",
+      "version": "15.5.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.5.7.tgz",
+      "integrity": "sha512-nfymt+SE5cvtTrG9u1wdoxBr9bVB7mtKTcj0ltRn6gkP/2Nu1zM5ei8rwP9qKQP0Y//umK+TtkKgNtfboBxRrw==",
       "cpu": [
         "arm64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -2040,12 +2047,13 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "15.4.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.4.7.tgz",
-      "integrity": "sha512-2uNXjxvONyRidg00VwvlTYDwC9EgCGNzPAPYbttIATZRxmOZ3hllk/YYESzHZb65eyZfBR5g9xgCZjRAl9YYGg==",
+      "version": "15.5.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.5.7.tgz",
+      "integrity": "sha512-hvXcZvCaaEbCZcVzcY7E1uXN9xWZfFvkNHwbe/n4OkRhFWrs1J1QV+4U1BN06tXLdaS4DazEGXwgqnu/VMcmqw==",
       "cpu": [
         "x64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -2055,12 +2063,13 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "15.4.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.4.7.tgz",
-      "integrity": "sha512-ceNbPjsFgLscYNGKSu4I6LYaadq2B8tcK116nVuInpHHdAWLWSwVK6CHNvCi0wVS9+TTArIFKJGsEyVD1H+4Kg==",
+      "version": "15.5.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.5.7.tgz",
+      "integrity": "sha512-4IUO539b8FmF0odY6/SqANJdgwn1xs1GkPO5doZugwZ3ETF6JUdckk7RGmsfSf7ws8Qb2YB5It33mvNL/0acqA==",
       "cpu": [
         "x64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -2070,12 +2079,13 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "15.4.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.4.7.tgz",
-      "integrity": "sha512-pZyxmY1iHlZJ04LUL7Css8bNvsYAMYOY9JRwFA3HZgpaNKsJSowD09Vg2R9734GxAcLJc2KDQHSCR91uD6/AAw==",
+      "version": "15.5.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.5.7.tgz",
+      "integrity": "sha512-CpJVTkYI3ZajQkC5vajM7/ApKJUOlm6uP4BknM3XKvJ7VXAvCqSjSLmM0LKdYzn6nBJVSjdclx8nYJSa3xlTgQ==",
       "cpu": [
         "arm64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -2085,12 +2095,13 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "15.4.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.4.7.tgz",
-      "integrity": "sha512-HjuwPJ7BeRzgl3KrjKqD2iDng0eQIpIReyhpF5r4yeAHFwWRuAhfW92rWv/r3qeQHEwHsLRzFDvMqRjyM5DI6A==",
+      "version": "15.5.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.5.7.tgz",
+      "integrity": "sha512-gMzgBX164I6DN+9/PGA+9dQiwmTkE4TloBNx8Kv9UiGARsr9Nba7IpcBRA1iTV9vwlYnrE3Uy6I7Aj6qLjQuqw==",
       "cpu": [
         "x64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -10108,9 +10119,9 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11728,11 +11739,12 @@
       }
     },
     "node_modules/next": {
-      "version": "15.4.7",
-      "resolved": "https://registry.npmjs.org/next/-/next-15.4.7.tgz",
-      "integrity": "sha512-OcqRugwF7n7mC8OSYjvsZhhG1AYSvulor1EIUsIkbbEbf1qoE5EbH36Swj8WhF4cHqmDgkiam3z1c1W0J1Wifg==",
+      "version": "15.5.9",
+      "resolved": "https://registry.npmjs.org/next/-/next-15.5.9.tgz",
+      "integrity": "sha512-agNLK89seZEtC5zUHwtut0+tNrc0Xw4FT/Dg+B/VLEo9pAcS9rtTKpek3V6kVcVwsB2YlqMaHdfZL4eLEVYuCg==",
+      "license": "MIT",
       "dependencies": {
-        "@next/env": "15.4.7",
+        "@next/env": "15.5.9",
         "@swc/helpers": "0.5.15",
         "caniuse-lite": "^1.0.30001579",
         "postcss": "8.4.31",
@@ -11745,14 +11757,14 @@
         "node": "^18.18.0 || ^19.8.0 || >= 20.0.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "15.4.7",
-        "@next/swc-darwin-x64": "15.4.7",
-        "@next/swc-linux-arm64-gnu": "15.4.7",
-        "@next/swc-linux-arm64-musl": "15.4.7",
-        "@next/swc-linux-x64-gnu": "15.4.7",
-        "@next/swc-linux-x64-musl": "15.4.7",
-        "@next/swc-win32-arm64-msvc": "15.4.7",
-        "@next/swc-win32-x64-msvc": "15.4.7",
+        "@next/swc-darwin-arm64": "15.5.7",
+        "@next/swc-darwin-x64": "15.5.7",
+        "@next/swc-linux-arm64-gnu": "15.5.7",
+        "@next/swc-linux-arm64-musl": "15.5.7",
+        "@next/swc-linux-x64-gnu": "15.5.7",
+        "@next/swc-linux-x64-musl": "15.5.7",
+        "@next/swc-win32-arm64-msvc": "15.5.7",
+        "@next/swc-win32-x64-msvc": "15.5.7",
         "sharp": "^0.34.3"
       },
       "peerDependencies": {
@@ -13005,14 +13017,15 @@
       }
     },
     "node_modules/purgecss/node_modules/glob": {
-      "version": "11.0.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-11.0.3.tgz",
-      "integrity": "sha512-2Nim7dha1KVkaiF4q6Dj+ngPPMdfvLJEOpZk/jKiUAkqKebpGAWQXAq9z1xu9HKu5lWfqw/FASuccEjyznjPaA==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-11.1.0.tgz",
+      "integrity": "sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw==",
       "dev": true,
+      "license": "BlueOak-1.0.0",
       "dependencies": {
         "foreground-child": "^3.3.1",
         "jackspeak": "^4.1.1",
-        "minimatch": "^10.0.3",
+        "minimatch": "^10.1.1",
         "minipass": "^7.1.2",
         "package-json-from-dist": "^1.0.0",
         "path-scurry": "^2.0.0"
@@ -13028,10 +13041,11 @@
       }
     },
     "node_modules/purgecss/node_modules/minimatch": {
-      "version": "10.0.3",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.0.3.tgz",
-      "integrity": "sha512-IPZ167aShDZZUMdRk66cyQAW3qr0WzbHkPdMYa8bzZhlHhO3jALbKdxcaak7W9FfT2rZNpQuUu4Od7ILEpXSaw==",
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.1.1.tgz",
+      "integrity": "sha512-enIvLvRAFZYXJzkCYG5RKmPfrFArdLv+R+lbQ53BmIMLIry74bjKzX6iHAm8WYamJkhSSEabrWN5D97XnKObjQ==",
       "dev": true,
+      "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/brace-expansion": "^5.0.0"
       },
@@ -14762,9 +14776,9 @@
       }
     },
     "node_modules/tar-fs": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.0.tgz",
-      "integrity": "sha512-5Mty5y/sOF1YWj1J6GiBodjlDc05CUR8PKXrsnFAiSG0xA+GHeWLovaZPYUDXkH/1iKRf2+M5+OrRgzC7O9b7w==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.1.tgz",
+      "integrity": "sha512-LZA0oaPOc2fVo82Txf3gw+AkEd38szODlptMYejQUhndHMLQ9M059uXR+AfS7DNo0NpINvSqDsvyaCrBVkptWg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -17253,9 +17267,9 @@
       }
     },
     "@next/env": {
-      "version": "15.4.7",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.4.7.tgz",
-      "integrity": "sha512-PrBIpO8oljZGTOe9HH0miix1w5MUiGJ/q83Jge03mHEE0E3pyqzAy2+l5G6aJDbXoobmxPJTVhbCuwlLtjSHwg=="
+      "version": "15.5.9",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.5.9.tgz",
+      "integrity": "sha512-4GlTZ+EJM7WaW2HEZcyU317tIQDjkQIyENDLxYJfSWlfqguN+dHkZgyQTV/7ykvobU7yEH5gKvreNrH4B6QgIg=="
     },
     "@next/eslint-plugin-next": {
       "version": "12.3.1",
@@ -17289,51 +17303,51 @@
       "requires": {}
     },
     "@next/swc-darwin-arm64": {
-      "version": "15.4.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.4.7.tgz",
-      "integrity": "sha512-2Dkb+VUTp9kHHkSqtws4fDl2Oxms29HcZBwFIda1X7Ztudzy7M6XF9HDS2dq85TmdN47VpuhjE+i6wgnIboVzQ==",
+      "version": "15.5.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.5.7.tgz",
+      "integrity": "sha512-IZwtxCEpI91HVU/rAUOOobWSZv4P2DeTtNaCdHqLcTJU4wdNXgAySvKa/qJCgR5m6KI8UsKDXtO2B31jcaw1Yw==",
       "optional": true
     },
     "@next/swc-darwin-x64": {
-      "version": "15.4.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.4.7.tgz",
-      "integrity": "sha512-qaMnEozKdWezlmh1OGDVFueFv2z9lWTcLvt7e39QA3YOvZHNpN2rLs/IQLwZaUiw2jSvxW07LxMCWtOqsWFNQg==",
+      "version": "15.5.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.5.7.tgz",
+      "integrity": "sha512-UP6CaDBcqaCBuiq/gfCEJw7sPEoX1aIjZHnBWN9v9qYHQdMKvCKcAVs4OX1vIjeE+tC5EIuwDTVIoXpUes29lg==",
       "optional": true
     },
     "@next/swc-linux-arm64-gnu": {
-      "version": "15.4.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.4.7.tgz",
-      "integrity": "sha512-ny7lODPE7a15Qms8LZiN9wjNWIeI+iAZOFDOnv2pcHStncUr7cr9lD5XF81mdhrBXLUP9yT9RzlmSWKIazWoDw==",
+      "version": "15.5.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.5.7.tgz",
+      "integrity": "sha512-NCslw3GrNIw7OgmRBxHtdWFQYhexoUCq+0oS2ccjyYLtcn1SzGzeM54jpTFonIMUjNbHmpKpziXnpxhSWLcmBA==",
       "optional": true
     },
     "@next/swc-linux-arm64-musl": {
-      "version": "15.4.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.4.7.tgz",
-      "integrity": "sha512-4SaCjlFR/2hGJqZLLWycccy1t+wBrE/vyJWnYaZJhUVHccpGLG5q0C+Xkw4iRzUIkE+/dr90MJRUym3s1+vO8A==",
+      "version": "15.5.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.5.7.tgz",
+      "integrity": "sha512-nfymt+SE5cvtTrG9u1wdoxBr9bVB7mtKTcj0ltRn6gkP/2Nu1zM5ei8rwP9qKQP0Y//umK+TtkKgNtfboBxRrw==",
       "optional": true
     },
     "@next/swc-linux-x64-gnu": {
-      "version": "15.4.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.4.7.tgz",
-      "integrity": "sha512-2uNXjxvONyRidg00VwvlTYDwC9EgCGNzPAPYbttIATZRxmOZ3hllk/YYESzHZb65eyZfBR5g9xgCZjRAl9YYGg==",
+      "version": "15.5.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.5.7.tgz",
+      "integrity": "sha512-hvXcZvCaaEbCZcVzcY7E1uXN9xWZfFvkNHwbe/n4OkRhFWrs1J1QV+4U1BN06tXLdaS4DazEGXwgqnu/VMcmqw==",
       "optional": true
     },
     "@next/swc-linux-x64-musl": {
-      "version": "15.4.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.4.7.tgz",
-      "integrity": "sha512-ceNbPjsFgLscYNGKSu4I6LYaadq2B8tcK116nVuInpHHdAWLWSwVK6CHNvCi0wVS9+TTArIFKJGsEyVD1H+4Kg==",
+      "version": "15.5.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.5.7.tgz",
+      "integrity": "sha512-4IUO539b8FmF0odY6/SqANJdgwn1xs1GkPO5doZugwZ3ETF6JUdckk7RGmsfSf7ws8Qb2YB5It33mvNL/0acqA==",
       "optional": true
     },
     "@next/swc-win32-arm64-msvc": {
-      "version": "15.4.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.4.7.tgz",
-      "integrity": "sha512-pZyxmY1iHlZJ04LUL7Css8bNvsYAMYOY9JRwFA3HZgpaNKsJSowD09Vg2R9734GxAcLJc2KDQHSCR91uD6/AAw==",
+      "version": "15.5.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.5.7.tgz",
+      "integrity": "sha512-CpJVTkYI3ZajQkC5vajM7/ApKJUOlm6uP4BknM3XKvJ7VXAvCqSjSLmM0LKdYzn6nBJVSjdclx8nYJSa3xlTgQ==",
       "optional": true
     },
     "@next/swc-win32-x64-msvc": {
-      "version": "15.4.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.4.7.tgz",
-      "integrity": "sha512-HjuwPJ7BeRzgl3KrjKqD2iDng0eQIpIReyhpF5r4yeAHFwWRuAhfW92rWv/r3qeQHEwHsLRzFDvMqRjyM5DI6A==",
+      "version": "15.5.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.5.7.tgz",
+      "integrity": "sha512-gMzgBX164I6DN+9/PGA+9dQiwmTkE4TloBNx8Kv9UiGARsr9Nba7IpcBRA1iTV9vwlYnrE3Uy6I7Aj6qLjQuqw==",
       "optional": true
     },
     "@nodelib/fs.scandir": {
@@ -22846,9 +22860,9 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
       "dev": true,
       "requires": {
         "argparse": "^2.0.1"
@@ -23932,19 +23946,19 @@
       "dev": true
     },
     "next": {
-      "version": "15.4.7",
-      "resolved": "https://registry.npmjs.org/next/-/next-15.4.7.tgz",
-      "integrity": "sha512-OcqRugwF7n7mC8OSYjvsZhhG1AYSvulor1EIUsIkbbEbf1qoE5EbH36Swj8WhF4cHqmDgkiam3z1c1W0J1Wifg==",
+      "version": "15.5.9",
+      "resolved": "https://registry.npmjs.org/next/-/next-15.5.9.tgz",
+      "integrity": "sha512-agNLK89seZEtC5zUHwtut0+tNrc0Xw4FT/Dg+B/VLEo9pAcS9rtTKpek3V6kVcVwsB2YlqMaHdfZL4eLEVYuCg==",
       "requires": {
-        "@next/env": "15.4.7",
-        "@next/swc-darwin-arm64": "15.4.7",
-        "@next/swc-darwin-x64": "15.4.7",
-        "@next/swc-linux-arm64-gnu": "15.4.7",
-        "@next/swc-linux-arm64-musl": "15.4.7",
-        "@next/swc-linux-x64-gnu": "15.4.7",
-        "@next/swc-linux-x64-musl": "15.4.7",
-        "@next/swc-win32-arm64-msvc": "15.4.7",
-        "@next/swc-win32-x64-msvc": "15.4.7",
+        "@next/env": "15.5.9",
+        "@next/swc-darwin-arm64": "15.5.7",
+        "@next/swc-darwin-x64": "15.5.7",
+        "@next/swc-linux-arm64-gnu": "15.5.7",
+        "@next/swc-linux-arm64-musl": "15.5.7",
+        "@next/swc-linux-x64-gnu": "15.5.7",
+        "@next/swc-linux-x64-musl": "15.5.7",
+        "@next/swc-win32-arm64-msvc": "15.5.7",
+        "@next/swc-win32-x64-msvc": "15.5.7",
         "@swc/helpers": "0.5.15",
         "caniuse-lite": "^1.0.30001579",
         "postcss": "8.4.31",
@@ -24789,23 +24803,23 @@
           "dev": true
         },
         "glob": {
-          "version": "11.0.3",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-11.0.3.tgz",
-          "integrity": "sha512-2Nim7dha1KVkaiF4q6Dj+ngPPMdfvLJEOpZk/jKiUAkqKebpGAWQXAq9z1xu9HKu5lWfqw/FASuccEjyznjPaA==",
+          "version": "11.1.0",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-11.1.0.tgz",
+          "integrity": "sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw==",
           "dev": true,
           "requires": {
             "foreground-child": "^3.3.1",
             "jackspeak": "^4.1.1",
-            "minimatch": "^10.0.3",
+            "minimatch": "^10.1.1",
             "minipass": "^7.1.2",
             "package-json-from-dist": "^1.0.0",
             "path-scurry": "^2.0.0"
           }
         },
         "minimatch": {
-          "version": "10.0.3",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.0.3.tgz",
-          "integrity": "sha512-IPZ167aShDZZUMdRk66cyQAW3qr0WzbHkPdMYa8bzZhlHhO3jALbKdxcaak7W9FfT2rZNpQuUu4Od7ILEpXSaw==",
+          "version": "10.1.1",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.1.1.tgz",
+          "integrity": "sha512-enIvLvRAFZYXJzkCYG5RKmPfrFArdLv+R+lbQ53BmIMLIry74bjKzX6iHAm8WYamJkhSSEabrWN5D97XnKObjQ==",
           "dev": true,
           "requires": {
             "@isaacs/brace-expansion": "^5.0.0"
@@ -26022,9 +26036,9 @@
       "integrity": "sha512-Re10+NauLTMCudc7T5WLFLAwDhQ0JWdrMK+9B2M8zR5hRExKmsRDCBA7/aV/pNJFltmBFO5BAMlQFi/vq3nKOg=="
     },
     "tar-fs": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.0.tgz",
-      "integrity": "sha512-5Mty5y/sOF1YWj1J6GiBodjlDc05CUR8PKXrsnFAiSG0xA+GHeWLovaZPYUDXkH/1iKRf2+M5+OrRgzC7O9b7w==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.1.tgz",
+      "integrity": "sha512-LZA0oaPOc2fVo82Txf3gw+AkEd38szODlptMYejQUhndHMLQ9M059uXR+AfS7DNo0NpINvSqDsvyaCrBVkptWg==",
       "dev": true,
       "requires": {
         "bare-fs": "^4.0.1",

--- a/pages/hall-of-fame.tsx
+++ b/pages/hall-of-fame.tsx
@@ -1,0 +1,54 @@
+import { useIntl } from 'react-intl';
+import Layout from '../components/Layout';
+import dynamic from 'next/dynamic';
+import { GetServerSideProps } from 'next';
+
+const DynamicHallOfFame = dynamic(() => import('../components/community/HallOfFame'), {
+  ssr: false,
+});
+
+type Props = {
+  teamMembers?: any;
+};
+
+export default function HallOfFamePage(props: Props) {
+  const intl = useIntl();
+  const title = intl.formatMessage({
+    id: 'hallOfFame.title',
+    defaultMessage: 'Hall of Fame',
+  });
+
+  return (
+    <div className="relative overflow-hidden">
+      <Layout title={title}>
+        <div className="pt-20">
+          {props.teamMembers ? (
+            <DynamicHallOfFame teamMembers={props.teamMembers} />
+          ) : null}
+        </div>
+      </Layout>
+    </div>
+  );
+}
+
+export const getServerSideProps: GetServerSideProps = async (context) => {
+  // Map app locale -> Strapi locale (cn -> zh)
+  const toStrapiLocale = (l: string) => (l === 'cn' ? 'zh' : l);
+
+  const appLocale = context.locale as string;
+  const mapped = toStrapiLocale(appLocale);
+
+  // Team members localized to current locale
+  const teamMembers = await fetch(
+    process.env.NEXT_PUBLIC_STRAPI_API +
+      '/api/team-members?pagination[pageSize]=100&populate=*&locale=' +
+      encodeURIComponent(mapped),
+  )
+    .then((response) => response.json())
+    .then((response) => response.data)
+    .catch(() => null);
+
+  return {
+    props: { teamMembers },
+  };
+};


### PR DESCRIPTION
This PR moves the Hall of Fame to its own dedicated page at /hall-of-fame.

The tabbed layout (Core / Community / Foundation) has been removed so all members are now shown together in a single, unified view. Navigation links across the site have been updated to point to the new page, and a redirect was added to preserve the old URL.

This improves discoverability and makes it easier to browse all contributors at once.

Fixes: #110